### PR TITLE
add wiki link for resident set size

### DIFF
--- a/guide/README.md
+++ b/guide/README.md
@@ -298,7 +298,7 @@ To keep overhead low, the memory profiler uses poisson sampling so that on avera
 For profiling in production, you should generally not have to modify the sampling rate. The only reason for doing so is if you're worried that not enough samples are getting collected in situations where very few allocations are taking place.
 ### Memory Inuse vs RSS
 
-A common confusion is looking at the total amount of memory reported by the `inuse_space/bytes` sample type, and noticing that it doesn't match up with the RSS memory usage reported by the operating system. There are various reasons for this:
+A common confusion is looking at the total amount of memory reported by the `inuse_space/bytes` sample type, and noticing that it doesn't match up with the [RSS](https://en.wikipedia.org/wiki/Resident_set_size) memory usage reported by the operating system. There are various reasons for this:
 
 - RSS includes a lot more than just Go heap memory usage by definition, e.g. the memory used by goroutine stacks, the program executable, shared libraries as well as memory allocated by C functions.
 - The GC may decide to not return free memory to the OS immediately, but this should be a lesser issue after [runtime changes in Go 1.16](https://golang.org/doc/go1.16#runtime).


### PR DESCRIPTION
Hey thanks a bunch for this guide.
I got a little confused when encountered the term _RSS_ (with RSS feeds). I understand the guide is meant for intermidate go users but I assume _Resident Set size_ is not sometthing folks usually talk about when profiling code. So to save some confusion I have added the wiki link for it.

I hope this doesn't pollute the guide. Feel free to close if it doesn't add any value.