### PR TITLE
Add link checker to detect broken links

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,18 @@
+name: CI
+
+on:
+  push:
+    branches: [ "main" ]
+  pull_request:
+    branches: [ "main" ]
+
+jobs:
+  check-links:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout
+        uses: actions/checkout@main
+      - name: Markup Link Checker (mlc)
+        uses: becheran/mlc@v0.15.4
+        with:
+          args: --no-web-links


### PR DESCRIPTION
Just a suggestion, the link checker would detect broken links via github action. 

Might be helpful for a repo which consists a lot of markdown files.