### PR TITLE
fix link target for new block-profile section

### DIFF
--- a/block.md
+++ b/block.md
@@ -1,6 +1,6 @@
 ⬅ [Index of all go-profiler-notes](./README.md)
 
-⚠ This page is deprecated in favor of the block profiler section in the [The Busy Developer's Guide to Go Profiling, Tracing and Observability](./guide/README.md#block).
+⚠ This page is deprecated in favor of the block profiler section in the [The Busy Developer's Guide to Go Profiling, Tracing and Observability](./guide/README.md#block-profiler).
 
 [Description](#description) - [Usage](#usage) - [Overhead](#overhead) - [Accuracy](#accuracy) - [Relationship with Mutex Profiling](#relationship-with-mutex-profiling) - [Profiler Labels](#profiler-labels) - [History](#history)
 


### PR DESCRIPTION
The link target seems to be `#block-profiler`, not `#block`.

PS: Thanks for all this! It is really helpful!